### PR TITLE
Root level schema should be always an object

### DIFF
--- a/example/cart.json
+++ b/example/cart.json
@@ -57,8 +57,13 @@
       "method": "GET",
       "authentication_needed": true,
       "targetSchema": {
-        "type": "array",
-        "items": {"rel": "self"}
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {"rel": "self"}
+          }
+        }
       }
     },
     {

--- a/example/product.json
+++ b/example/product.json
@@ -105,8 +105,13 @@
         }
       },
       "targetSchema": {
-        "type": "array",
-        "items": {"rel": "self"}
+        "type": "object",
+        "properties": {
+          "products": {
+            "type": "array",
+            "items": {"rel": "self"}
+          }
+        }
       }
     },{
       "title": "Product info",


### PR DESCRIPTION
Although `[]` is a valid json, it's not a good practice for APIs to return an array (it's not descriptive, makes impossible to add new data into payload without breaking stuff...).

Instead of this:

```
[
  {key: 1},
  {key: 2}
]
```

API should rather return something like this:

```
{ 
  items: [
    {key: 1},
    {key: 2}
  ]
}
```

So I'm fixing that in our example schemas. Also, our docs generator ignores root level arrays right  now. The transformed example is just an empty `{}`.
