### PR TITLE
Update dependencies, add intro, document more things.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -2,26 +2,22 @@
 export default {
   title: 'Example API Documentation',
   // enhance your CURL examples by base url and request headers...
-  /*curl: {
-    baseUrl: 'https://api.example.com/client/v4',
+  curl: {
+    // The baseUrl typically ends in a / so that relative hrefs
+    // in your schemas can be joined with it in accordance
+    // with RFC 3986 relative URI reference resolution rules.
+    //
+    // By default, the generated app's src/client/introduction.js
+    // component displays this baseUrl in your documentation.
+    baseUrl: 'https://api.example.com/example/v1/',
     requestHeaders: {
+      // This is a JSON Schema which treats the HTTP request
+      // headers as if they were a JSON object instance.
       required: [
         'Content-Type',
-        'X-Auth-Email',
-        'X-Auth-Key',
       ],
       properties: {
-        'X-Auth-Email': {
-          type: 'string',
-          description: 'Your email',
-          example: 'user@example.com',
-        },
-        'X-Auth-Key': {
-          type: 'string',
-          length: 45,
-          description: 'Your API key',
-          example: 'c2547eb745079abc9320b638f5e225cf483cc5cfdda41',
-        },
+        // Include other headers here, such as for auth
         'Content-Type': {
           type: 'string',
           enum: [
@@ -32,5 +28,5 @@ export default {
         },
       },
     },
-  },*/
+  },
 };

--- a/app/getting-started.json
+++ b/app/getting-started.json
@@ -1,0 +1,19 @@
+{
+  "id": "/getting/started",
+  "title": "Getting started",
+  "hidden": true,
+  "links": [
+    {
+      "title": "Endpoints"
+    },
+    {
+      "title": "Requests"
+    },
+    {
+      "title": "Responses"
+    },
+    {
+      "title": "Resource IDs"
+    }
+  ]
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-api-documentation",
   "version": "0.0.1",
-  "description": "Example API documentation",
+  "description": "Example API Documentation",
   "license": "None",
   "private": true,
   "engines": {
@@ -42,7 +42,7 @@
     "immutable": "^3.8.1",
     "ip": "^1.1.3",
     "json-loader": "^0.5.4",
-    "json-schema-example-loader": "^1.0.0",
+    "json-schema-example-loader": "^2.0.0",
     "json-schema-loader": "^1.0.0",
     "less": "^2.5.1",
     "less-loader": "^2.0.0",

--- a/app/schemas.js
+++ b/app/schemas.js
@@ -3,5 +3,9 @@
 import { fromJS } from 'immutable';
 
 export default fromJS([
+  // The "getting started" schema provides table-of-contents links
+  // for the sections in src/client/introduction.js.  You are free
+  // to customize or remove both the schema and the introduction component.
+  require('./getting-started.json'),
 ###schemas###
 ]);

--- a/app/src/client/introduction.js
+++ b/app/src/client/introduction.js
@@ -1,0 +1,60 @@
+/* eslint max-len: 0 */
+/* eslint react/jsx-indent: 0 */
+/* eslint react/no-unescaped-entities: 0 */
+
+import React from 'react';
+import Component from 'react-pure-render/component';
+import config from '../../config';
+
+/* This is a placeholder for introductory content.  It is connected
+ * to the table of contents by the getting-started.json file in
+ * the root directory of the generated app.  You will want to
+ * customize or replace this!
+ */
+class Introduction extends Component {
+
+  render() {
+    return (
+      <div>
+        <article className="section api-section">
+          <p>
+            <small>Last modified: {(new Date(LAST_MODIFIED)).toDateString()}</small>
+          </p>
+          <h2>Getting started</h2>
+
+          <p>Lorem ipsum...</p>
+        </article>
+        <article className="section api-section">
+            <a className="anchor2" id="getting-started-endpoints">
+              getting-started-endpoints
+            </a>
+            <h2>Endpoints</h2>
+
+            <p>Lorem ipsum...</p>
+
+            <p>The base URL for all endpoints in this API is:</p>
+            <p className="CodeMirror cm-s-default">{config.curl.baseUrl}</p>
+        </article>
+
+        <article className="section api-section">
+          <a className="anchor2" id="getting-started-requests">
+            getting-started-requests
+          </a>
+          <h2>Requests</h2>
+          <p>Lorem ipsum...</p>
+        </article>
+
+        <article className="section api-section">
+          <a className="anchor2" id="getting-started-responses">
+            getting-started-responses
+          </a>
+          <h2>Responses</h2>
+          <p>Lorem ipsum...</p>
+        </article>
+
+      </div>
+    );
+  }
+}
+
+module.exports = Introduction;

--- a/app/src/client/main.js
+++ b/app/src/client/main.js
@@ -1,14 +1,15 @@
 import { connect } from 'react-redux';
-import { App } from 'doca-cf-theme';
+import { App } from 'doca-bootstrap-theme';
+import Introduction from './introduction';
 import config from '../../config';
 
 // this dynamically imports css, less and sass from the "THEME/styles"
 try {
-  const reqCSS = require.context('doca-cf-theme/styles', true, /\.css$/ig);
+  const reqCSS = require.context('doca-bootstrap-theme/styles', true, /\.css$/ig);
   reqCSS.keys().forEach(reqCSS);
-  const reqLESS = require.context('doca-cf-theme/styles', true, /\.less$/ig);
+  const reqLESS = require.context('doca-bootstrap-theme/styles', true, /\.less$/ig);
   reqLESS.keys().forEach(reqLESS);
-  const reqSASS = require.context('doca-cf-theme/styles', true, /\.scss$/ig);
+  const reqSASS = require.context('doca-bootstrap-theme/styles', true, /\.scss$/ig);
   reqSASS.keys().forEach(reqSASS);
 } catch (e) {
   // no theme styles were found
@@ -17,6 +18,7 @@ try {
 const mapStateToProps = state => ({
   schemas: state.schemas,
   config,
+  introduction: Introduction,
 });
 
 const Main = connect(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doca",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A CLI tool that scaffolds API documentation based on JSON HyperSchemas.",
   "main": "./lib/main.js",
   "bin": {


### PR DESCRIPTION
This updates doca to use the latest json-schema-example-loader 2.0.0.
It also adds a "getting started" introduction section and a way
to hook it to the table of contents, and documents a few more
things in the config file.  The config file now starts uncommented,
as it has a reasonable default for the headers.