### PR TITLE
Document @namespaced/doca-*-theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This sets a different theme `newTheme` to the `project`. It has two steps:
 - renames all `doca-xxx-theme` references to `doca-newTheme-theme`
 **This can make destructive changes in your project.** Always use version control!
 
+**A note about package namespaces:** While non-namespaced themes can be referenced by their simple name (e.g. `newTheme` for `doca-newTheme-theme`), namespaced theme packages such as `@myorg/doca-abc-theme` must be passed as the full package name, including the namespace.
+
 ### help
 
 ```

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,7 @@ program
   .command('init')
   .option(
     '-t, --theme <theme>',
-    `Doca theme. ${chalk.grey('Default')}: ${chalk.green('bootstrap')}`
+    `Doca theme. Must be the full package name if @namespaced. ${chalk.grey('Default')}: ${chalk.green('bootstrap')}`
   )
   .option(
     '-i, --input <input>',
@@ -28,7 +28,7 @@ program
 
 program
   .command('theme <newTheme> <project>')
-  .description('set project <project> theme to <newTheme>')
+  .description('set project <project> theme to <newTheme>; note that @namespaced theme packages must be given with their full package name')
   .action(setTheme);
 
 if (!process.argv.slice(2).length) {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -39,7 +39,7 @@ function installTheme(theme, project) {
 
 function normalizeName(theme) {
   var themeName = `doca-${theme}-theme`;
-  if (theme.indexOf('doca-') > -1) {
+  if (theme.indexOf('doca-') > -1 || theme.indexOf('@') === 0) {
     themeName = theme;
   }
   return themeName;


### PR DESCRIPTION
Namespaced themes can't be abbreviated.

Probably not the best solution but will be less confusing as a start.