### PR TITLE
Support scoped packages, update dependencies and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.4.0
+
+* Use [json-schema-example-loader 3.0.0](https://github.com/cloudflare/json-schema-example-loader/blob/master/CHANGELOG.md).
+* Use [doca-bootstrap-theme 1.0.0](https://github.com/cloudflare/doca-cf-theme),
+  which adds support for nested objects and arrays, as well as the
+  `format`, `exclusiveMinimum`, `exclusiveMaximum`,
+  `minProperties`, `maxProperties`, `minItems`, `maxItems`, and `uniqueItems`
+  draft-04 keywords.  It also provides a number of minor UI enhancements.
+* Support using @scoped packages for themes, although only with full package name.
+
 ## v0.3.0
 
 * Use [json-schema-example-loader 2.0.0](https://github.com/cloudflare/json-schema-example-loader/blob/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This sets a different theme `newTheme` to the `project`. It has two steps:
 - renames all `doca-xxx-theme` references to `doca-newTheme-theme`
 **This can make destructive changes in your project.** Always use version control!
 
+**A note about package scopes:** While non-scoped themes can be referenced by their simple name (e.g. `newTheme` for `doca-newTheme-theme`), scoped theme packages such as `@myscope/doca-abc-theme` must be passed as the full package name, including the scope.
+
 ### help
 
 ```
@@ -120,7 +122,9 @@ You can **install any theme** with the command
 doca theme THEME_NAME documentation
 ```
 
-You can use full name `doca-THEME_NAME-theme` or just shortcut `THEME_NAME`.
+For non-scoped theme packages, you can use full name `doca-THEME_NAME-theme` or just shortcut `THEME_NAME`.
+
+For scoped theme packages, you must use the full name `@myscope/doca-THEME_NAME-theme`
 
 
 

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
     "immutable": "^3.8.1",
     "ip": "^1.1.3",
     "json-loader": "^0.5.4",
-    "json-schema-example-loader": "^2.0.0",
+    "json-schema-example-loader": "^3.0.0",
     "json-schema-loader": "^1.0.0",
     "less": "^2.5.1",
     "less-loader": "^2.0.0",

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,7 @@ program
   .command('init')
   .option(
     '-t, --theme <theme>',
-    `Doca theme. ${chalk.grey('Default')}: ${chalk.green('bootstrap')}`
+    `Doca theme. Must be the full package name if @scoped. ${chalk.grey('Default')}: ${chalk.green('bootstrap')}`
   )
   .option(
     '-i, --input <input>',
@@ -28,7 +28,7 @@ program
 
 program
   .command('theme <newTheme> <project>')
-  .description('set project <project> theme to <newTheme>')
+  .description('set project <project> theme to <newTheme>; note that @namespaced theme packages must be given with their full package name')
   .action(setTheme);
 
 if (!process.argv.slice(2).length) {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -8,7 +8,7 @@ function replaceTheme(theme, project) {
   console.log(`Setting ${chalk.green(project)} theme to ${chalk.green(theme)}. Files changed:`);
   try {
     replace({
-      regex: /doca-([-_a-z0-9]+)-theme/ig,
+      regex: /(?:@[^ \/]+\/)?doca-([-_a-z0-9]+)-theme/ig,
       replacement: theme,
       recursive: true,
       paths: [
@@ -39,7 +39,7 @@ function installTheme(theme, project) {
 
 function normalizeName(theme) {
   var themeName = `doca-${theme}-theme`;
-  if (theme.indexOf('doca-') > -1) {
+  if (theme.indexOf('doca-') > -1 || theme.indexOf('@') === 0) {
     themeName = theme;
   }
   return themeName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doca",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A CLI tool that scaffolds API documentation based on JSON HyperSchemas.",
   "main": "./lib/main.js",
   "bin": {


### PR DESCRIPTION
This release of doca moves to the 1.0.0 theme and the 3.0.0 example loader,
and also supports scoped packages as themes (although they cannot be abbreviated).